### PR TITLE
Refresh news styles with neutral slate palette

### DIFF
--- a/newsBS/static/newsBS/css/detail.css
+++ b/newsBS/static/newsBS/css/detail.css
@@ -6,17 +6,21 @@
 }
 
 :root {
-  --primary-color: #ee517bff;
-  --secondary-color: #f8fafc;
-  --text-primary: #0f1115ff;
-  --text-secondary: #191e25ff;
-  --border-color: #e2e8f0;
-  --hover-color: #f1f5f9;
-  --success-color: #12ca8cff;
-  --warning-color: #f59e0b;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --primary-color: #4f5d8c;
+  --primary-color-dark: #384872;
+  --primary-color-light: #6d7bab;
+  --secondary-color: #f2f4f8;
+  --text-primary: #1c2333;
+  --text-secondary: #404b66;
+  --text-tertiary: #5a6480;
+  --border-color: #d5dbe6;
+  --hover-color: #e6e9f3;
+  --success-color: #3ba58b;
+  --warning-color: #c58b30;
+  --info-color: #6174a6;
+  --shadow-sm: 0 1px 2px 0 rgb(15 23 42 / 0.08);
+  --shadow-md: 0 8px 16px -4px rgb(15 23 42 / 0.15), 0 3px 6px -2px rgb(15 23 42 / 0.1);
+  --shadow-lg: 0 20px 35px -10px rgb(15 23 42 / 0.25), 0 10px 15px -10px rgb(15 23 42 / 0.15);
 }
 
 body {
@@ -39,7 +43,7 @@ body {
 
 /* Clean pot header */
 .pot-header {
-  background: linear-gradient(180deg, var(--primary-color) 0%, #fa6ca7ff 100%);
+  background: linear-gradient(180deg, var(--primary-color) 0%, var(--primary-color-dark) 100%);
   padding: 3rem 2rem 2rem;
   position: relative;
   color: white;
@@ -64,7 +68,7 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.85);
   font-size: 0.875rem;
 }
 
@@ -76,7 +80,7 @@ body {
 .dot {
   width: 4px;
   height: 4px;
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.75);
   border-radius: 50%;
   animation: steam 2s ease-in-out infinite;
 }
@@ -101,7 +105,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(255, 255, 255, 0.9);
   font-size: 0.9rem;
 }
 
@@ -136,7 +140,7 @@ body {
 }
 
 .action-button {
-  background: linear-gradient(135deg, var(--primary-color) 0%, #fa6ca7ff 100%);
+  background: linear-gradient(135deg, var(--primary-color-light) 0%, var(--primary-color) 50%, var(--primary-color-dark) 100%);
   color: white;
   border: none;
   border-radius: 50px;
@@ -349,7 +353,7 @@ body {
 .ai-icon {
   width: 24px;
   height: 24px;
-  background: linear-gradient(135deg, var(--primary-color) 0%, #fa6ca7ff 100%);
+  background: linear-gradient(135deg, var(--primary-color-light) 0%, var(--primary-color) 100%);
   border-radius: 8px;
   display: flex;
   align-items: center;

--- a/newsBS/static/newsBS/css/index.css
+++ b/newsBS/static/newsBS/css/index.css
@@ -6,15 +6,17 @@
 }
 
 :root {
-  --primary-color: #ee517bff;
-  --secondary-color: #f8fafc;
-  --text-primary: #1e293b;
-  --text-secondary: #64748b;
-  --border-color: #e2e8f0;
-  --hover-color: #f1f5f9;
-  --success-color: #12ca8cff;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --primary-color: #4f5d8c;
+  --primary-color-dark: #384872;
+  --secondary-color: #f2f4f8;
+  --text-primary: #1c2333;
+  --text-secondary: #4a556f;
+  --border-color: #d5dbe6;
+  --hover-color: #e6e9f3;
+  --success-color: #3ba58b;
+  --info-color: #6174a6;
+  --shadow-sm: 0 1px 2px 0 rgb(15 23 42 / 0.08);
+  --shadow-md: 0 8px 16px -4px rgb(15 23 42 / 0.15), 0 3px 6px -2px rgb(15 23 42 / 0.1);
 }
 
 body {
@@ -62,7 +64,7 @@ body {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
-  color: var(--text-secondary);
+  color: var(--info-color);
 }
 
 .live-dot {


### PR DESCRIPTION
## Summary
- replace shared CSS tokens with a neutral slate palette in the index and detail stylesheets
- update gradients and interactive UI treatments to consume the new neutral design tokens
- tweak header indicator styling to preserve readable contrast on the refreshed backgrounds

## Testing
- not run (CSS-only updates)


------
https://chatgpt.com/codex/tasks/task_e_68dcbb73aee4832eb7946366e93d7144