### PR TITLE
Add unread state styling and persistence improvements

### DIFF
--- a/newsBS/static/newsBS/css/index.css
+++ b/newsBS/static/newsBS/css/index.css
@@ -197,6 +197,15 @@ body {
   transform-origin: bottom;
 }
 
+.news-item.unread::before {
+  transform: scaleY(1);
+  background: linear-gradient(to bottom, var(--primary-color), var(--primary-color-dark));
+}
+
+.news-item.read::before {
+  transform: scaleY(0);
+}
+
 .news-item:hover {
   background-color: var(--hover-color);
   transform: translateX(8px);
@@ -230,6 +239,25 @@ body {
   margin-bottom: 0.5rem;
   transition: color 0.3s ease;
   word-wrap: break-word;
+}
+
+.news-item.unread .news-title {
+  color: var(--primary-color-dark);
+  font-weight: 700;
+}
+
+.news-item.read .news-title {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.news-item.read .news-meta {
+  color: rgba(74, 85, 111, 0.7);
+}
+
+.news-item.read {
+  background-color: rgba(242, 244, 248, 0.4);
+  transition: background-color 0.3s ease, transform 0.3s ease;
 }
 
 .news-item:hover .news-title {

--- a/newsBS/static/newsBS/js/script.js
+++ b/newsBS/static/newsBS/js/script.js
@@ -44,30 +44,46 @@ document.addEventListener("DOMContentLoaded", function() {
 // Mark article as read
 function markAsRead(linkElement) {
     const newsItem = linkElement.closest('.news-item');
-    const articleUrl = newsItem.getAttribute('data-article-url');
-    
+    if (!newsItem) {
+        return;
+    }
+
+    const articleUrl = newsItem.getAttribute('data-article-url') || linkElement.getAttribute('data-article-url');
+    if (!articleUrl) {
+        return;
+    }
+
     // Update visual state
     newsItem.classList.remove('unread');
     newsItem.classList.add('read');
-    
+
     // Save to localStorage
     let readArticles = JSON.parse(localStorage.getItem("readArticles")) || [];
     if (!readArticles.includes(articleUrl)) {
-    readArticles.push(articleUrl);
-    localStorage.setItem("readArticles", JSON.stringify(readArticles));
+        readArticles.push(articleUrl);
+        localStorage.setItem("readArticles", JSON.stringify(readArticles));
     }
 }
 
 // Initialize read/unread states from localStorage
 function initializeReadStates() {
     const readArticles = JSON.parse(localStorage.getItem("readArticles")) || [];
-    
+
     document.querySelectorAll('.news-item').forEach(item => {
-    const articleUrl = item.getAttribute('data-article-url');
-    if (readArticles.includes(articleUrl)) {
-        item.classList.remove('unread');
-        item.classList.add('read');
-    }
+        const linkElement = item.querySelector('.news-link');
+        const articleUrl = item.getAttribute('data-article-url') || (linkElement ? linkElement.getAttribute('data-article-url') : null);
+
+        if (!articleUrl) {
+            return;
+        }
+
+        if (readArticles.includes(articleUrl)) {
+            item.classList.remove('unread');
+            item.classList.add('read');
+        } else {
+            item.classList.remove('read');
+            item.classList.add('unread');
+        }
     });
 }
 

--- a/newsBS/templates/newsBS/index.html
+++ b/newsBS/templates/newsBS/index.html
@@ -45,7 +45,7 @@
         <h2 class="section-title">Online Khabar</h2>
         <ul class="news-list">
           {% for article in onlinekhabar %}
-          <li class="news-item">
+          <li class="news-item unread" data-article-url="{{ article.link }}">
             <a href="{% url 'news_detail' %}?url={{ article.link }}" class="news-link" data-article-url="{{ article.link }}" onclick="markAsRead(this);" target="_blank">
               <div class="news-content">
                 <div class="news-title">{{ article.title }}</div>
@@ -71,8 +71,8 @@
         <h2 class="section-title">Routine of Nepal Banda</h2>
         <ul class="news-list">
           {% for article in ronb %}
-          <li class="news-item">
-            <a href="{{ article.link }}" class="news-link" target="_blank">
+          <li class="news-item unread" data-article-url="{{ article.link }}">
+            <a href="{{ article.link }}" class="news-link" data-article-url="{{ article.link }}" target="_blank">
               <div class="news-content">
                 <div class="news-title">{{ article.title }}</div>
                 <div class="news-meta">
@@ -97,8 +97,8 @@
         <h2 class="section-title">Hamro Patro</h2>
         <ul class="news-list">
           {% for article in hp %}
-          <li class="news-item">
-            <a href="{{ article.link }}" class="news-link" target="_blank">
+          <li class="news-item unread" data-article-url="{{ article.link }}">
+            <a href="{{ article.link }}" class="news-link" data-article-url="{{ article.link }}" target="_blank">
               <div class="news-content">
                 <div class="news-title">{{ article.title }}</div>
                 <div class="news-meta">


### PR DESCRIPTION
## Summary
- add unread state metadata to each news item so articles carry their canonical link
- update read-state helpers to pull URLs from the list item attributes with anchor fallbacks while persisting to localStorage
- style unread versus read items with distinct accents for clearer visual cues

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcbd84a1cc832e82bf5d1c7f3307ce