### PR TITLE
Add live headline updates and API endpoint

### DIFF
--- a/newsBS/static/newsBS/js/script.js
+++ b/newsBS/static/newsBS/js/script.js
@@ -1,73 +1,258 @@
-
 // Tab functionality
 function showTab(tabId, tabElement) {
     // Remove active class from all tabs and content
     document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
     document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
-    
+
     // Add active class to clicked tab and corresponding content
     tabElement.classList.add('active');
     document.getElementById(tabId).classList.add('active');
 }
 
+const FETCH_INTERVAL = parseInt(document.body.dataset.fetchInterval || '80000', 10);
+const FETCH_URL = document.body.dataset.fetchUrl || '';
+const NEWS_DETAIL_BASE = document.body.dataset.newsDetailUrl || '';
+let seenLinksCache = new Set(JSON.parse(localStorage.getItem('seenNews')) || []);
+let initialUpdate = true;
+
 // News notification system
-document.addEventListener("DOMContentLoaded", function() {
-    // Initialize read/unread states
-    initializeReadStates();
-    
-    let storedLinks = JSON.parse(localStorage.getItem("seenNews")) || [];
-    
-    // Collect all current article links from the DOM
-    let currentLinks = Array.from(document.querySelectorAll(".news-link"))
-    .map(a => a.getAttribute("href"));
-    
-    // Find new links
-    let newLinks = currentLinks.filter(link => !storedLinks.includes(link));
-    
-    if (newLinks.length > 0 && storedLinks.length > 0) {
-    // Play sound only if it's not the first load
-    const audio = document.getElementById("newsSound");
+// Handle live updates without full page refresh
+async function fetchAndUpdate() {
+    if (!FETCH_URL) {
+        return;
+    }
+
+    try {
+        const response = await fetch(FETCH_URL, { headers: { 'Accept': 'application/json' } });
+        if (!response.ok) {
+            throw new Error(`Failed to fetch latest headlines: ${response.status}`);
+        }
+
+        const data = await response.json();
+        const newArticlesCount = applyUpdates(data || {});
+
+        updateSeenNewsCacheFromDom();
+        initializeReadStates();
+
+        if (newArticlesCount > 0 && !initialUpdate) {
+            triggerNewArticleFeedback(newArticlesCount);
+        }
+    } catch (error) {
+        console.error('Live update error:', error);
+    } finally {
+        initialUpdate = false;
+    }
+}
+
+function applyUpdates(payload) {
+    let newCount = 0;
+    newCount += updateSource('onlinekhabar', payload.onlinekhabar, {
+        transformLink: createDetailLink,
+        supportsReadState: true,
+    });
+    newCount += updateSource('ronb', payload.ronb);
+    newCount += updateSource('hp', payload.hp);
+    return newCount;
+}
+
+function updateSource(sectionId, articles, options = {}) {
+    const section = document.getElementById(sectionId);
+    if (!section || !Array.isArray(articles)) {
+        return 0;
+    }
+
+    const list = section.querySelector('.news-list');
+    if (!list) {
+        return 0;
+    }
+
+    const existingLinks = new Set(
+        Array.from(list.querySelectorAll('.news-item'))
+            .map(getArticleUrlFromItem)
+            .filter(Boolean)
+    );
+
+    // Remove empty state placeholders when fresh data arrives
+    if (articles.length) {
+        list.querySelectorAll('.empty-state').forEach(node => node.remove());
+    }
+
+    let newItems = 0;
+
+    articles.forEach(article => {
+        const articleLink = article && article.link;
+        if (!articleLink || existingLinks.has(articleLink)) {
+            return;
+        }
+
+        const listItem = document.createElement('li');
+        listItem.className = 'news-item unread';
+        listItem.dataset.articleUrl = articleLink;
+
+        const anchor = document.createElement('a');
+        anchor.className = 'news-link';
+        anchor.target = '_blank';
+        anchor.rel = 'noopener noreferrer';
+        anchor.href = options.transformLink ? options.transformLink(articleLink) : articleLink;
+
+        if (options.supportsReadState) {
+            anchor.dataset.articleUrl = articleLink;
+            anchor.addEventListener('click', () => markAsRead(anchor));
+        }
+
+        const content = document.createElement('div');
+        content.className = 'news-content';
+
+        const titleDiv = document.createElement('div');
+        titleDiv.className = 'news-title';
+        titleDiv.textContent = article.title || '';
+        content.appendChild(titleDiv);
+
+        const metaDiv = document.createElement('div');
+        metaDiv.className = 'news-meta';
+
+        const timeDiv = document.createElement('div');
+        timeDiv.className = 'news-time';
+        timeDiv.textContent = article.time || '';
+        metaDiv.appendChild(timeDiv);
+
+        content.appendChild(metaDiv);
+        anchor.appendChild(content);
+
+        const indicator = document.createElement('div');
+        indicator.className = 'external-indicator';
+        anchor.appendChild(indicator);
+
+        listItem.appendChild(anchor);
+
+        const firstElement = list.firstElementChild;
+        if (firstElement) {
+            list.insertBefore(listItem, firstElement);
+        } else {
+            list.appendChild(listItem);
+        }
+
+        existingLinks.add(articleLink);
+        if (!seenLinksCache.has(articleLink)) {
+            newItems += 1;
+        }
+    });
+
+    return newItems;
+}
+
+function createDetailLink(articleLink) {
+    if (!NEWS_DETAIL_BASE) {
+        return articleLink;
+    }
+
+    try {
+        const detailUrl = new URL(NEWS_DETAIL_BASE, window.location.origin);
+        detailUrl.searchParams.set('url', articleLink);
+        return `${detailUrl.pathname}${detailUrl.search}`;
+    } catch (error) {
+        console.warn('Failed to construct detail URL, falling back to article link.', error);
+        return articleLink;
+    }
+}
+
+function triggerNewArticleFeedback(count) {
+    if (count <= 0) {
+        return;
+    }
+
+    const audio = document.getElementById('newsSound');
     if (audio) {
-        audio.play().catch(e => {
-        console.log("Autoplay blocked, user interaction needed:", e);
+        audio.play().catch(err => {
+            console.log('Autoplay blocked, user interaction needed:', err);
         });
     }
-    
-    // Show notification
-    showNewArticlesNotification(newLinks.length);
+
+    showNewArticlesNotification(count);
+}
+
+function startLiveUpdates() {
+    if (!FETCH_URL) {
+        console.warn('Live update endpoint is not configured.');
+        return;
     }
-    
-    // Save current links for next refresh
-    localStorage.setItem("seenNews", JSON.stringify(currentLinks));
+
+    fetchAndUpdate();
+
+    if (Number.isFinite(FETCH_INTERVAL) && FETCH_INTERVAL > 0) {
+        setInterval(fetchAndUpdate, FETCH_INTERVAL);
+    }
+}
+
+function getArticleUrlFromItem(item) {
+    if (!item) {
+        return null;
+    }
+
+    return (
+        item.dataset.articleUrl ||
+        (item.querySelector('.news-link') && (item.querySelector('.news-link').dataset.articleUrl || item.querySelector('.news-link').getAttribute('href')))
+    );
+}
+
+function updateSeenNewsCacheFromDom() {
+    const allLinks = Array.from(document.querySelectorAll('.news-item'))
+        .map(getArticleUrlFromItem)
+        .filter(Boolean);
+
+    seenLinksCache = new Set(allLinks);
+    localStorage.setItem('seenNews', JSON.stringify(Array.from(seenLinksCache)));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initializeReadStates();
+    updateSeenNewsCacheFromDom();
+    startLiveUpdates();
 });
 
 // Mark article as read
 function markAsRead(linkElement) {
+    if (!linkElement) {
+        return;
+    }
+
     const newsItem = linkElement.closest('.news-item');
-    const articleUrl = newsItem.getAttribute('data-article-url');
-    
-    // Update visual state
+    if (!newsItem) {
+        return;
+    }
+
+    const articleUrl = linkElement.dataset.articleUrl || newsItem.dataset.articleUrl || linkElement.getAttribute('href');
+    if (!articleUrl) {
+        return;
+    }
+
     newsItem.classList.remove('unread');
     newsItem.classList.add('read');
-    
-    // Save to localStorage
-    let readArticles = JSON.parse(localStorage.getItem("readArticles")) || [];
+
+    let readArticles = JSON.parse(localStorage.getItem('readArticles')) || [];
     if (!readArticles.includes(articleUrl)) {
-    readArticles.push(articleUrl);
-    localStorage.setItem("readArticles", JSON.stringify(readArticles));
+        readArticles.push(articleUrl);
+        localStorage.setItem('readArticles', JSON.stringify(readArticles));
     }
 }
 
 // Initialize read/unread states from localStorage
 function initializeReadStates() {
-    const readArticles = JSON.parse(localStorage.getItem("readArticles")) || [];
-    
+    const readArticles = JSON.parse(localStorage.getItem('readArticles')) || [];
+
     document.querySelectorAll('.news-item').forEach(item => {
-    const articleUrl = item.getAttribute('data-article-url');
-    if (readArticles.includes(articleUrl)) {
-        item.classList.remove('unread');
-        item.classList.add('read');
-    }
+        const articleUrl = getArticleUrlFromItem(item);
+        if (!articleUrl) {
+            return;
+        }
+
+        if (readArticles.includes(articleUrl)) {
+            item.classList.add('read');
+            item.classList.remove('unread');
+        } else {
+            item.classList.add('unread');
+            item.classList.remove('read');
+        }
     });
 }
 
@@ -88,9 +273,9 @@ function showNewArticlesNotification(count) {
     animation: slideInRight 0.3s ease-out;
     `;
     notification.textContent = `${count} new article${count > 1 ? 's' : ''} available!`;
-    
+
     document.body.appendChild(notification);
-    
+
     // Remove after 3 seconds
     setTimeout(() => {
     notification.style.animation = 'slideOutRight 0.3s ease-out';

--- a/newsBS/templates/newsBS/index.html
+++ b/newsBS/templates/newsBS/index.html
@@ -7,7 +7,11 @@
 <title>Samrey's Newspot</title>
 <link rel="stylesheet" href="{% static 'newsBS/css/index.css' %}">
 </head>
-<body data-fetch-url="{% url 'fetch_latest_headlines' %}" data-news-detail-url="{% url 'news_detail' %}" data-fetch-interval="80000">
+<body
+  data-fetch-url="{% url 'fetch_latest_headlines' %}"
+  data-news-detail-url="{% url 'news_detail' %}"
+  data-fetch-interval="80000"
+>
   <header class="header">
     <div class="container">
       <div class="header-content">
@@ -44,7 +48,7 @@
         <h2 class="section-title">Online Khabar</h2>
         <ul class="news-list">
           {% for article in onlinekhabar %}
-          <li class="news-item unread" data-article-url="{{ article.link }}">
+          <li class="news-item unread" data-article-url="{{ article.link }}" data-supports-read-state="true">
             <a href="{% url 'news_detail' %}?url={{ article.link }}" class="news-link" data-article-url="{{ article.link }}" onclick="markAsRead(this);" target="_blank">
               <div class="news-content">
                 <div class="news-title">{{ article.title }}</div>

--- a/newsBS/templates/newsBS/index.html
+++ b/newsBS/templates/newsBS/index.html
@@ -4,11 +4,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="refresh" content="80">
 <title>Samrey's Newspot</title>
 <link rel="stylesheet" href="{% static 'newsBS/css/index.css' %}">
 </head>
-<body>
+<body data-fetch-url="{% url 'fetch_latest_headlines' %}" data-news-detail-url="{% url 'news_detail' %}" data-fetch-interval="80000">
   <header class="header">
     <div class="container">
       <div class="header-content">
@@ -45,7 +44,7 @@
         <h2 class="section-title">Online Khabar</h2>
         <ul class="news-list">
           {% for article in onlinekhabar %}
-          <li class="news-item">
+          <li class="news-item unread" data-article-url="{{ article.link }}">
             <a href="{% url 'news_detail' %}?url={{ article.link }}" class="news-link" data-article-url="{{ article.link }}" onclick="markAsRead(this);" target="_blank">
               <div class="news-content">
                 <div class="news-title">{{ article.title }}</div>
@@ -71,7 +70,7 @@
         <h2 class="section-title">Routine of Nepal Banda</h2>
         <ul class="news-list">
           {% for article in ronb %}
-          <li class="news-item">
+          <li class="news-item" data-article-url="{{ article.link }}">
             <a href="{{ article.link }}" class="news-link" target="_blank">
               <div class="news-content">
                 <div class="news-title">{{ article.title }}</div>
@@ -97,7 +96,7 @@
         <h2 class="section-title">Hamro Patro</h2>
         <ul class="news-list">
           {% for article in hp %}
-          <li class="news-item">
+          <li class="news-item" data-article-url="{{ article.link }}">
             <a href="{{ article.link }}" class="news-link" target="_blank">
               <div class="news-content">
                 <div class="news-title">{{ article.title }}</div>

--- a/newsBS/urls.py
+++ b/newsBS/urls.py
@@ -4,5 +4,6 @@ from . import views
 urlpatterns = [
     path('', views.index, name='indexpage'),
     path("news-detail/", views.news_detail, name="news_detail"),
-    path("ai-helper/", views.ai_helper, name="ai_helper")
+    path("ai-helper/", views.ai_helper, name="ai_helper"),
+    path("fetch-latest/", views.fetch_latest_headlines, name="fetch_latest_headlines"),
 ]

--- a/newsBS/views.py
+++ b/newsBS/views.py
@@ -202,6 +202,14 @@ def ai_helper(request):
             return JsonResponse({"error": str(e)}, status=500)
 
 
+def fetch_latest_headlines(request):
+    """Return the most recent scrape results for each supported news source."""
+    payload = {
+        "ronb": scrape_ronbpost(),
+        "onlinekhabar": scrape_onlinekhabar(),
+        "hp": scrape_hamropatro(),
+    }
+    return JsonResponse(payload)
 
 
 # ========================

--- a/newsBS/views.py
+++ b/newsBS/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.http import Http404, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET
 import requests
 from bs4 import BeautifulSoup
 import os
@@ -202,6 +203,7 @@ def ai_helper(request):
             return JsonResponse({"error": str(e)}, status=500)
 
 
+@require_GET
 def fetch_latest_headlines(request):
     """Return the most recent scrape results for each supported news source."""
     payload = {


### PR DESCRIPTION
## Summary
- remove the hard refresh meta tag and expose fetch configuration on the index template
- add a JSON endpoint that returns the latest scrape results and register it with the router
- poll the new endpoint from the frontend, append only new stories, and preserve read/unread state with notifications

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dcbd7120ac832eba29de01b6fcf34e